### PR TITLE
fix: add frontend build fallback to deployment workflow

### DIFF
--- a/.github/workflows/_reusable_deploy.yml
+++ b/.github/workflows/_reusable_deploy.yml
@@ -53,9 +53,28 @@ jobs:
         run: |
           echo "Downloading frontend artifact from CI run ${{ inputs.ci-run-id }}"
           gh run download ${{ inputs.ci-run-id }} --name frontend-dist --dir frontend/dist || {
-            echo "::warning::Failed to download frontend artifact, will build locally if needed"
+            echo "::warning::Failed to download frontend artifact, will build locally"
             mkdir -p frontend/dist
           }
+
+      - name: Setup Node.js for frontend build
+        if: hashFiles('frontend/dist/**') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+          cache-dependency-path: yarn.lock
+
+      - name: Build frontend if artifact unavailable
+        run: |
+          if [ ! -d "frontend/dist" ] || [ -z "$(ls -A frontend/dist)" ]; then
+            echo "Frontend dist is empty, building frontend..."
+            corepack enable
+            yarn install --immutable
+            yarn workspace careercopilot-frontend build
+          else
+            echo "Frontend artifact found, skipping build"
+          fi
 
       - name: Authenticate to Google Cloud
         id: auth


### PR DESCRIPTION
## Summary
Adds frontend build fallback when artifact download fails in deployment workflow.

## Problem
- Cross-workflow artifact downloads can fail (different run IDs)
- Deployment was failing with empty frontend dist directory
- Error: "Frontend dist directory is empty or doesn't exist"

## Solution
- ✅ Add Node.js setup step before build attempt
- ✅ Build frontend locally if artifact download fails
- ✅ Check if dist directory is empty before building
- ✅ Graceful fallback ensures deployment always succeeds

## Changes
1. Added `Setup Node.js for frontend build` step (conditional)
2. Added `Build frontend if artifact unavailable` step
3. Builds using `yarn workspace careercopilot-frontend build`

## Benefits
- Deployment workflow is more resilient
- No manual intervention needed when artifacts unavailable
- Works with both automatic and manual triggers

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)