### PR TITLE
chore(design): tighten orchestrator docs and CI trigger

### DIFF
--- a/.claude/skills/SKILL_REGISTRY.md
+++ b/.claude/skills/SKILL_REGISTRY.md
@@ -3,10 +3,26 @@
 _Last updated: 2026-02-28_
 
 ## Summary
-- Active skills: **67**
+- Active skills: **65**
 - Legacy/placeholder cleanup applied: **yes**
 - Manifest v6.0.0 — 71 assets (32 PNG + 39 SVG), all validated ✅
 - Recommended asset audit combo: **vision-scorer-mcp + asset-placement-strategy + batch-processor**
+
+
+
+## Lifecycle Clusters (Orchestrator Era)
+
+- **Orchestrator + Batch (Primary entrypoints)**: `frontend-design-orchestrator` (repo command layer), `sprint-coordinator`, `batch-processor`, `project-health-checker`, `compliance-dashboard`.
+- **Design Skill Internals (WRAPPED by orchestrator)**: `component-spec-scaffolder`, `wireframe-annotator`, `asset-placement-strategy`, `hifi-blueprint-linter`, `component-builder`, `component-transformer`, `design-token-validator`, `token-orchestrator`, `asset-path-validator`, `asset-token-replacer`, `component-visual-audit`, `vision-scorer-mcp`, `manifest-reconciler`.
+- **Legacy/Low-level (DEMOTED)**: one-off scaffolders and direct generators not used as top-level workflow controls.
+- **Deprecated/Retired**: skills archived under `.claude/skills/_legacy_archive/`.
+
+### Registry Hygiene
+
+Use `node scripts/design/registry-hygiene.mjs` (or `yarn design:registry:hygiene`) to:
+1. Recompute active-skill counts from `.claude/skills/*/SKILL.md`
+2. Compare declared summary count vs parsed active count
+3. Emit orphaned/legacy skill diagnostics
 
 ## Asset Audit Workflow (>=90)
 1. Validate tokens and semantic variable usage (--sys-color-*, --sys-type-*).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       e2e: ${{ steps.filter.outputs.e2e }}
       performance: ${{ steps.filter.outputs.performance }}
       extension: ${{ steps.filter.outputs.extension }}
+      design: ${{ steps.filter.outputs.design }}
     if: github.event_name != 'workflow_dispatch'
     steps:
       - name: Checkout
@@ -76,6 +77,11 @@ jobs:
               - *backend-paths
             performance:
               - *backend-paths
+            design:
+              - 'design/**'
+              - 'docs/design/**'
+              - 'scripts/design/**'
+              - 'package.json'
             extension:
               - 'chrome-extension/**'
 
@@ -163,6 +169,42 @@ jobs:
         uses: actions/checkout@v4
       - name: Run docs policy check
         run: ./scripts/check-docs.sh
+
+
+  design-orchestrator:
+    name: Design Orchestrator Gate
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.design == 'true')
+    needs: [changes]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Enable Corepack for Yarn 4+
+        run: corepack enable
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+          cache-dependency-path: yarn.lock
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Run design orchestrator
+        run: yarn design:orchestrate:all
+      - name: Upload design artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: design-orchestrator-artifacts
+          path: |
+            docs/design/generated/design-readiness.json
+            docs/design/design-readiness.md
+            docs/design/generated/visual-audit-gallery.md
+            docs/design/runs/
+            docs/design/generated/previews/
+          if-no-files-found: warn
 
   extension-build:
     name: Extension Build

--- a/design/contracts/behavior/README.md
+++ b/design/contracts/behavior/README.md
@@ -1,0 +1,3 @@
+# Behavior Contracts
+
+Spec-first behavior contracts (JSON) belong in this directory.

--- a/design/contracts/copy/README.md
+++ b/design/contracts/copy/README.md
@@ -1,0 +1,3 @@
+# Copy Contracts
+
+Spec-first copy contracts (JSON/MD) belong in this directory.

--- a/design/contracts/layout/README.md
+++ b/design/contracts/layout/README.md
@@ -1,0 +1,9 @@
+# Layout Contracts
+
+Spec-first layout contracts (JSON) belong in this directory.
+
+Expected shape (v1):
+- id
+- route
+- regions[]
+- componentArchetypes[]

--- a/design/contracts/runtime-probes.json
+++ b/design/contracts/runtime-probes.json
@@ -1,0 +1,35 @@
+{
+  "targets": [
+    {
+      "targetId": "dashboard-overview",
+      "url": "http://127.0.0.1:5173/dashboard",
+      "checks": [
+        {
+          "type": "selectorExists",
+          "selector": "#root"
+        }
+      ]
+    },
+    {
+      "targetId": "analysis-dashboard",
+      "url": "http://127.0.0.1:5173/analysis",
+      "checks": [
+        {
+          "type": "selectorExists",
+          "selector": "#root"
+        }
+      ]
+    },
+    {
+      "targetId": "onboarding-screen",
+      "url": "http://127.0.0.1:5173/onboarding",
+      "checks": [
+        {
+          "type": "selectorExists",
+          "selector": "#root"
+        }
+      ]
+    }
+  ],
+  "note": "INITIAL_SCAFFOLD_TODO: Runtime probes are baseline checks only (selector existence); expand to Lens/Jar token and CSS assertions."
+}

--- a/design/contracts/skill-lifecycle.json
+++ b/design/contracts/skill-lifecycle.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0.0",
+  "source": "docs/design/design-skill-lifecycle.md",
+  "skills": [
+    {"name": "component-spec-scaffolder", "state": "WRAP", "stage": "spec-generation"},
+    {"name": "wireframe-annotator", "state": "WRAP", "stage": "wireframe-generation"},
+    {"name": "asset-placement-strategy", "state": "WRAP", "stage": "asset-placement"},
+    {"name": "hifi-blueprint-linter", "state": "WRAP", "stage": "hifi-lint"},
+    {"name": "component-builder", "state": "WRAP", "stage": "component-generation"},
+    {"name": "component-transformer", "state": "WRAP", "stage": "component-migration"},
+    {"name": "design-system-doc-generator", "state": "WRAP", "stage": "docs-protocol-sync"},
+    {"name": "component-spec-generator", "state": "DEMOTE", "stage": "manual"},
+    {"name": "asset-token-replacer", "state": "WRAP", "stage": "token-safety-batch-linter"},
+    {"name": "asset-path-validator", "state": "WRAP", "stage": "path-normalizer"},
+    {"name": "token-orchestrator", "state": "WRAP", "stage": "token-safety-batch-linter"},
+    {"name": "design-token-validator", "state": "WRAP", "stage": "token-safety-batch-linter"},
+    {"name": "manifest-reconciler", "state": "WRAP", "stage": "asset-reconciliation"},
+    {"name": "vision-scorer-mcp", "state": "DEMOTE", "stage": "visual-audit-optional"},
+    {"name": "component-visual-audit", "state": "WRAP", "stage": "visual-audit"},
+    {"name": "compliance-dashboard", "state": "DEMOTE", "stage": "reporting"},
+    {"name": "storybook-scaffolder", "state": "DEMOTE", "stage": "manual"},
+    {"name": "jest-test-scaffolder", "state": "DEMOTE", "stage": "manual"}
+  ]
+}

--- a/design/contracts/visual-audit-targets.json
+++ b/design/contracts/visual-audit-targets.json
@@ -1,0 +1,24 @@
+{
+  "baseUrl": "http://127.0.0.1:5173",
+  "targets": [
+    {
+      "id": "dashboard-overview",
+      "route": "/dashboard",
+      "component": "DashboardOverview",
+      "priority": "P0"
+    },
+    {
+      "id": "analysis-dashboard",
+      "route": "/analysis",
+      "component": "AnalysisDashboard",
+      "priority": "P0"
+    },
+    {
+      "id": "onboarding-screen",
+      "route": "/onboarding",
+      "component": "OnboardingScreen",
+      "priority": "P1"
+    }
+  ],
+  "note": "INITIAL_SCAFFOLD_TODO: Visual audit target set is a starter list and not yet full Lens/Jar coverage."
+}

--- a/docs/design/automation-status.md
+++ b/docs/design/automation-status.md
@@ -48,3 +48,23 @@ The custom skills appear to have produced intermediate documentation artifacts, 
 - Added initial design contracts for visual targets and runtime probes under `design/contracts/`.
 - Added run/readiness artifacts and visual gallery outputs under `docs/design/generated/` and `docs/design/runs/`.
 - CI now includes a design orchestrator gate that fails on orchestrator `fail` status.
+
+
+## Legacy Workflow De-authorization
+
+The previous queue/stage-based automation tracking (e.g., old Kerala Rage queue documents) is no longer authoritative for release readiness.
+
+Authoritative readiness now comes from orchestrator artifacts:
+- `docs/design/generated/design-readiness.json`
+- `docs/design/design-readiness.md`
+- `docs/design/runs/<timestamp>.json`
+
+Legacy process documents should be treated as historical context and gradually archived/quarantined under legacy sections.
+
+
+## Skill Lifecycle + Registry Hygiene
+
+- Lifecycle decisions are now documented in `docs/design/design-skill-lifecycle.md` (WRAP / DEMOTE / RETIRE).
+- Added registry hygiene command: `yarn design:registry:hygiene` (script: `scripts/design/registry-hygiene.mjs`).
+- Hygiene report output: `docs/design/generated/skill-registry-hygiene.json`.
+- `SKILL_REGISTRY.md` summary was corrected to match active table count and now includes orchestrator-era lifecycle clusters.

--- a/docs/design/automation-status.md
+++ b/docs/design/automation-status.md
@@ -1,38 +1,50 @@
 # Kerala Rage Automation Status
 
-**Last Updated**: 2026-02-10T12:45:00Z
-**Overall Progress**: 8/12 Components Aligned (Refined Audit: Stages/Tests/Tokens)
+**Last Updated**: 2026-03-05T00:00:00Z  
+**Audit Mode**: Custom skill verification (`component-spec-scaffolder`, `wireframe-annotator`, `asset-placement-strategy`, `hifi-blueprint-linter`, `component-builder`, `component-transformer`)  
+**Overall Status**: ❌ **Not complete** (automation artifacts exist, but implementation and compliance gates are failing)
 
-## Work Queues
+## Verification Summary
 
-### Queue A: Stage 1 (Structure)
-*New components needing Protocols, Wireframes, and Specs.*
-- [x] NewModule (Completed 2026-02-09)
-- [ ] TestComponentA (Blocked)
+### 1) Component Spec Scaffolder
+- **Expected output path (from skill contract)**: `docs/design/specs/`
+- **Observed**: `docs/design/specs/` contains **0 files**.
+- **Observed alternate path**: specs were generated under `docs/design/generated/specs/`.
+- **Quality result**: generated specs include hardcoded hex/Tailwind bracket colors (non-token compliant), e.g. `bg-[#1a1a1a]`, `text-[#F14714]`.
+- **Status**: ⚠️ Partially executed, **not compliant**.
 
-### Queue B: Stage 2 (Visuals)
-*Components with Structure complete, needing Mockups and Code.*
-- [x] TestComponentB (Completed 2026-02-09)
-- [ ] NewModule (Ready for Stage 2)
+### 2) Wireframe Annotator
+- **Expected structure**: XML blocks for `<layout>`, `<tokens>`, `<accessibility>`, `<states>`, `<assets>`.
+- **Observed**:
+  - `<layout>`/`<tokens>`/`<assets>` present in many generated files.
+  - `<accessibility>` and `<states>` appear in only a subset of generated wireframes.
+  - Some wireframes contain `[DEPRECATED_STYLE]` markers and hardcoded hex examples.
+- **Status**: ⚠️ Partially executed, **inconsistent completion**.
 
-### Queue C: Tests
-*Components needing unit/regression tests (Target Axis: basic/full).*
-- [ ] Lens (High Priority)
-- [ ] Jar (High Priority)
+### 3) Asset Placement Strategy
+- **Expected output**: placement report with deterministic scoring and manifest-valid mappings.
+- **Observed**: `docs/design/asset-placement-report-ui-primitives.json` exists and reports high scores.
+- **Gap**: no evidence that scored placements are fully reflected in active frontend styles/components; active theme stylesheet still contains hardcoded color values.
+- **Status**: ⚠️ Report generated, **integration not fully verified**.
 
-### Queue D: Migration Cleanup
-*Components with hardcoded values needing token migration (Axis: strict).*
-- [ ] Lens (High Priority)
-- [ ] Jar (High Priority)
+### 4) Active Frontend Theme Compliance Check
+- **File checked**: `frontend/src/design/styles/kerala-rage.css`.
+- **Observed**: hardcoded hex + rgba values remain in active stylesheet (e.g., `#050403`, `rgba(0, 0, 0, 0.15)`).
+- **Implication**: dev server can still render legacy/deprecated styling behaviors despite token infrastructure existing.
+- **Status**: ❌ Non-compliant with strict token-only requirement.
 
-## 📊 Summary (Granular Audit)
-| Status | Count | Components |
-| :--- | :--- | :--- |
-| ✅ Aligned | 8 | ManifestoCard, LoginCard, JobList, ApplicationForm, ProfileHeader, SkillBreakdownCard, KanbanCard, PathSelectionCard |
-| ⚠️  Blocked | 4 | NewModule (Needs Stage 2), TestComponentB (Needs Tests/Cleanup), Lens, Jar |
-| 🟠 At-Risk | 0 | - |
+## Current Conclusion
+The custom skills appear to have produced intermediate documentation artifacts, but the migration is **not finished** and does **not** meet strict kerala-rage token compliance in active runtime styling.
 
-## Loop History
-- **2026-02-09**: Initialized orchestrator loop. Baseline audit completed.
-- **2026-02-10**: Refined inventory script (JSON mode) and target state schema (Stages/Tests/Tokens).
-- **2026-02-10**: Updated auditor to enforce granular axes. Verified 8/12 alignment.
+## Recommended Next Actions
+1. Treat `docs/design/generated/specs/` as draft output only until normalized to `docs/design/specs/` and linted for token compliance.
+2. Run a wireframe normalization pass to require all five XML sections (`layout/tokens/accessibility/states/assets`) for every generated screen.
+3. Add a CI lint gate that fails on hex/rgb/rgba in active frontend styling files (`frontend/src/design/styles/*.css`, component styles).
+4. Re-run placement validation after style migration and compare report entries to actual component usage.
+
+
+## Orchestrator Bootstrap (Workflow A)
+- Added first-pass batch orchestrator commands: `design:orchestrate:all`, `design:orchestrate:visual-audit`.
+- Added initial design contracts for visual targets and runtime probes under `design/contracts/`.
+- Added run/readiness artifacts and visual gallery outputs under `docs/design/generated/` and `docs/design/runs/`.
+- CI now includes a design orchestrator gate that fails on orchestrator `fail` status.

--- a/docs/design/design-orchestrator-plan.md
+++ b/docs/design/design-orchestrator-plan.md
@@ -80,3 +80,17 @@ After running either orchestrator command, check:
 - `docs/design/runs/<timestamp>.json`
 - `docs/design/generated/visual-audit-gallery.md`
 - `docs/design/generated/previews/<targetId>.png`
+
+
+## Entrypoint Policy
+
+- Primary top-level design automation entrypoint: orchestrator commands only.
+- Legacy one-off skills may execute only as orchestrator-internal wrappers (not as primary release gates).
+
+
+## Skill Invocation Policy (Cleanup Phase)
+
+- Skill lifecycle decisions are tracked in `docs/design/design-skill-lifecycle.md`.
+- Machine-readable lifecycle state is tracked in `design/contracts/skill-lifecycle.json`.
+- Orchestrator wrapper stage (`legacy-skill-wrapper-map`) validates WRAP skills are present before downstream stages execute.
+- Non-orchestrated direct skill usage is considered low-level/manual and should not be used as release gate authority.

--- a/docs/design/design-orchestrator-plan.md
+++ b/docs/design/design-orchestrator-plan.md
@@ -1,0 +1,82 @@
+# Frontend Design Orchestrator Plan (Workflow A Backbone)
+
+## Decision Alignment
+
+- Workflow A (Spec-first Canonical): **GO (primary)**
+- Workflow B (Figma-first hybrid): **LATER / OPTIONAL**
+- Workflow C (Runtime reverse-doc): **LATER / SUPPORTING**
+- Workflow D (Asset-first composition): **DEFERRED**
+
+## Sprint-style Execution Plan
+
+### Sprint 1 — Orchestrator Skeleton + Artifacts (Current)
+
+**Goal:** Establish a single batch entrypoint and produce deterministic run/readiness artifacts.
+
+Delivered:
+- `scripts/design/orchestrate.mjs`
+- `yarn design:orchestrate:all`
+- `yarn design:orchestrate:visual-audit`
+- Run manifest output in `docs/design/runs/<timestamp>.json`
+- CI readiness JSON output in `docs/design/generated/design-readiness.json`
+- Human-readable readiness MD in `docs/design/design-readiness.md`
+- Visual audit gallery in `docs/design/generated/visual-audit-gallery.md`
+
+### Sprint 2 — Contract Hardening and Expanded Runtime Probes
+
+**Goal:** Increase confidence in visual/runtime compliance on critical screens.
+
+Planned:
+- Expand `design/contracts/runtime-probes.json` with selector + CSS assertions per target
+- Add explicit schema versioning for contracts
+- Add stricter visual-audit failure semantics by target priority
+
+### Sprint 3 — Wrap Legacy Skills Under Orchestrator
+
+**Goal:** Keep existing custom skills but run them as sub-steps under one gate.
+
+Planned:
+- Wrap existing generators/linters under orchestrator stages
+- Normalize all generated outputs to canonical paths
+- Emit one consolidated readiness decision for CI/CD
+
+### Sprint 4 — Optional Adapters and Cleanup
+
+**Goal:** Add optional integrations and remove obsolete one-offs.
+
+Planned:
+- Optional Figma layout adapter (LATER)
+- SKILL_REGISTRY consistency checker (lower-priority GO)
+- Archive deprecated one-off skills after orchestrator parity
+
+## Local Run Commands
+
+```bash
+# Full batch flow: audit + validate + visual checkpoint pass + reports
+yarn design:orchestrate:all
+
+# Visual-only checkpoint flow
+yarn design:orchestrate:visual-audit
+```
+
+## Current Known Constraint
+
+Visual audit requires reachable pages from `design/contracts/visual-audit-targets.json`
+(base URL defaults to `http://127.0.0.1:5173`).
+
+
+## Scaffold status (important)
+
+- Current visual audit targets and runtime probes are **initial scaffolding/TODO**.
+- They are not yet complete enforcement for all complex pages (Lens/Jar/etc.).
+- Current probes are intentionally minimal and will be expanded in Sprint 2.
+
+## Local verification outputs
+
+After running either orchestrator command, check:
+
+- `docs/design/generated/design-readiness.json`
+- `docs/design/design-readiness.md`
+- `docs/design/runs/<timestamp>.json`
+- `docs/design/generated/visual-audit-gallery.md`
+- `docs/design/generated/previews/<targetId>.png`

--- a/docs/design/design-skill-lifecycle.md
+++ b/docs/design/design-skill-lifecycle.md
@@ -1,0 +1,49 @@
+# Design Skill Lifecycle (Spec-first Batch Orchestrator)
+
+This document records lifecycle decisions for design automation skills under the `frontend-design-orchestrator` model.
+
+Legend:
+- **WRAP**: Skill remains but is invoked as orchestrator-internal stage logic.
+- **DEMOTE**: Skill remains available but is not a primary workflow entrypoint.
+- **RETIRE**: Planned deprecation/removal after orchestrator parity.
+
+## Primary + Supporting Skill Decisions
+
+| Skill | Decision | Reason | Orchestrator Stage |
+|---|---|---|---|
+| component-spec-scaffolder | WRAP | Produces useful artifacts but path/token drift must be gated centrally | `spec-generation` |
+| wireframe-annotator | WRAP | Valuable generator; needs XML contract checks from centralized gate | `wireframe-generation` + `wireframe-contract-validator` |
+| asset-placement-strategy | WRAP | Keep placement logic but run behind batch validation and readiness scoring | `asset-placement` |
+| hifi-blueprint-linter | WRAP | Good linting utility but should be orchestrator-internal | `hifi-lint` |
+| component-builder | WRAP | Keep as implementation utility, not top-level flow primitive | `component-generation` |
+| component-transformer | WRAP | Core migration utility; governed by orchestrator checks | `component-migration` |
+| design-system-doc-generator | WRAP | Input protocol helper; no direct top-level pipeline control | `docs-protocol-sync` |
+| component-spec-generator | DEMOTE | Overlaps spec-scaffolder path; kept for low-level/manual use | n/a (manual) |
+| asset-token-replacer | WRAP | Useful as sub-step in token safety remediation | `token-safety-batch-linter` |
+| asset-path-validator | WRAP | Batch path verification stage | `path-normalizer` |
+| token-orchestrator | WRAP | Token quality logic should feed orchestrator gate | `token-safety-batch-linter` |
+| design-token-validator | WRAP | Structured token checks integrated as gate signal | `token-safety-batch-linter` |
+| manifest-reconciler | WRAP | Required for asset consistency in batch runs | `asset-reconciliation` |
+| vision-scorer-mcp | DEMOTE | Useful but optional until visual gate hardening completes | optional `visual-audit` enhancer |
+| component-visual-audit | WRAP | Supports screenshot validation under visual audit stage | `visual-audit` |
+| compliance-dashboard | DEMOTE | Reporting tool, not control plane | n/a (reporting) |
+| storybook-scaffolder | DEMOTE | Useful utility, not pipeline primitive | n/a (manual) |
+| jest-test-scaffolder | DEMOTE | Test helper; not orchestrator gate itself | n/a (manual) |
+
+## Retire Candidates (post-parity)
+
+These should be retired only after orchestrator stages reach functional parity:
+
+- Direct single-file design generators that bypass contract + readiness gates.
+- Any legacy queue-based process docs claiming authority over design readiness.
+
+## Source of Truth (Design Automation)
+
+Primary readiness outputs now come from:
+
+- `docs/design/generated/design-readiness.json`
+- `docs/design/design-readiness.md`
+- `docs/design/runs/<timestamp>.json`
+- `docs/design/generated/visual-audit-gallery.md`
+
+Legacy queue-based status should be treated as archival context only.

--- a/docs/design/legacy/README-automation-workflows.md
+++ b/docs/design/legacy/README-automation-workflows.md
@@ -1,0 +1,18 @@
+# Legacy Automation Workflows (Archived)
+
+This folder quarantines legacy queue/stage workflow guidance that is no longer authoritative.
+
+## Not authoritative for release readiness
+
+Old multi-queue/stage tracking docs are retained only for historical context.
+
+## Current source of truth
+
+Use orchestrator artifacts instead:
+- `docs/design/generated/design-readiness.json`
+- `docs/design/design-readiness.md`
+- `docs/design/runs/<timestamp>.json`
+
+## Migration policy
+
+Any remaining references to old queue-based automation should be updated to point to orchestrator outputs.

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "docs:clean": "rimraf docs/api",
     "docs:build": "yarn docs:clean && yarn docs",
     "design:orchestrate:all": "node scripts/design/orchestrate.mjs --mode=all",
-    "design:orchestrate:visual-audit": "node scripts/design/orchestrate.mjs --mode=visual-audit"
+    "design:orchestrate:visual-audit": "node scripts/design/orchestrate.mjs --mode=visual-audit",
+    "design:registry:hygiene": "node scripts/design/registry-hygiene.mjs"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,9 @@
     "docs": "jsdoc -c jsdoc.config.json",
     "docs:serve": "serve docs/api",
     "docs:clean": "rimraf docs/api",
-    "docs:build": "yarn docs:clean && yarn docs"
+    "docs:build": "yarn docs:clean && yarn docs",
+    "design:orchestrate:all": "node scripts/design/orchestrate.mjs --mode=all",
+    "design:orchestrate:visual-audit": "node scripts/design/orchestrate.mjs --mode=visual-audit"
   },
   "config": {
     "commitizen": {

--- a/scripts/design/orchestrate.mjs
+++ b/scripts/design/orchestrate.mjs
@@ -58,6 +58,33 @@ function rel(p) {
   return path.relative(ROOT, p);
 }
 
+
+function legacySkillWrapperCheck() {
+  const lifecyclePath = path.join(ROOT, 'design/contracts/skill-lifecycle.json');
+  const missing = [];
+  const wrapped = [];
+
+  const lifecycle = fs.existsSync(lifecyclePath)
+    ? readJson(lifecyclePath)
+    : { skills: [] };
+
+  const wrappedSkills = (lifecycle.skills || []).filter((s) => s.state === 'WRAP').map((s) => s.name);
+
+  for (const skill of wrappedSkills) {
+    const skillPath = path.join(ROOT, '.claude/skills', skill, 'SKILL.md');
+    if (fs.existsSync(skillPath)) wrapped.push(skill);
+    else missing.push(skill);
+  }
+
+  return {
+    name: 'legacy-skill-wrapper-map',
+    passed: missing.length === 0,
+    details: { wrappedSkills: wrapped.length, missingSkills: missing.length },
+    violations: missing.map((skill) => ({ type: 'missing_wrapped_skill', skill })),
+    wrapped,
+  };
+}
+
 function pathNormalizerCheck() {
   const violations = [];
   const generatedSpecs = path.join(ROOT, 'docs/design/generated/specs');
@@ -335,6 +362,7 @@ async function main() {
 
   const stages = [];
   if (mode === 'all') {
+    stages.push(legacySkillWrapperCheck());
     stages.push(pathNormalizerCheck());
     stages.push(tokenSafetyCheck());
     stages.push(wireframeContractCheck());

--- a/scripts/design/orchestrate.mjs
+++ b/scripts/design/orchestrate.mjs
@@ -1,0 +1,379 @@
+#!/usr/bin/env node
+/**
+ * frontend-design-orchestrator scaffold (integrated v1).
+ *
+ * This file intentionally keeps path-normalizer, token-safety-batch-linter,
+ * wireframe-contract-validator, and visual-audit stages in one module so we can
+ * ship a single batch entrypoint quickly.
+ *
+ * Future hardening will extract these stages into dedicated modules while
+ * preserving the same CLI contract:
+ *   - design:orchestrate:all
+ *   - design:orchestrate:visual-audit
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+
+const ROOT = process.cwd();
+const modeArg = process.argv.find((a) => a.startsWith('--mode='));
+const mode = modeArg ? modeArg.split('=')[1] : 'all';
+const runId = new Date().toISOString().replace(/[:.]/g, '-');
+
+const paths = {
+  visualTargets: path.join(ROOT, 'design/contracts/visual-audit-targets.json'),
+  runtimeProbes: path.join(ROOT, 'design/contracts/runtime-probes.json'),
+  runsDir: path.join(ROOT, 'docs/design/runs'),
+  readinessJson: path.join(ROOT, 'docs/design/generated/design-readiness.json'),
+  readinessMd: path.join(ROOT, 'docs/design/design-readiness.md'),
+  galleryMd: path.join(ROOT, 'docs/design/generated/visual-audit-gallery.md'),
+  previewsDir: path.join(ROOT, 'docs/design/generated/previews'),
+};
+
+function ensureDir(p) {
+  fs.mkdirSync(p, { recursive: true });
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function walk(dir, exts = null) {
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walk(full, exts));
+    } else if (!exts || exts.includes(path.extname(entry.name))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function rel(p) {
+  return path.relative(ROOT, p);
+}
+
+function pathNormalizerCheck() {
+  const violations = [];
+  const generatedSpecs = path.join(ROOT, 'docs/design/generated/specs');
+  const canonicalSpecs = path.join(ROOT, 'docs/design/specs');
+
+  const generated = walk(generatedSpecs, ['.md']);
+  const canonical = walk(canonicalSpecs, ['.md']);
+
+  if (generated.length > 0) {
+    violations.push({
+      type: 'path_mismatch',
+      message: `Found ${generated.length} specs in docs/design/generated/specs; canonical path is docs/design/specs`,
+      files: generated.map(rel),
+    });
+  }
+
+  return {
+    name: 'path-normalizer',
+    passed: violations.length === 0,
+    details: {
+      generatedSpecsCount: generated.length,
+      canonicalSpecsCount: canonical.length,
+    },
+    violations,
+  };
+}
+
+function tokenSafetyCheck() {
+  const scanRoots = [
+    path.join(ROOT, 'docs/design/generated/specs'),
+    path.join(ROOT, 'docs/design/generated/wireframes'),
+    path.join(ROOT, 'frontend/src'),
+  ];
+
+  const patterns = [
+    { id: 'hardcoded_hex', re: /#[0-9A-Fa-f]{3,8}\b/g },
+    { id: 'hardcoded_rgba', re: /rgba?\(/g },
+    { id: 'deprecated_marker', re: /\[DEPRECATED_STYLE\]/g },
+  ];
+
+  const violations = [];
+
+  for (const root of scanRoots) {
+    for (const file of walk(root, ['.md', '.tsx', '.ts', '.css'])) {
+      const txt = fs.readFileSync(file, 'utf8');
+      const lines = txt.split(/\r?\n/);
+      for (const ptn of patterns) {
+        for (let i = 0; i < lines.length; i++) {
+          if (ptn.re.test(lines[i])) {
+            violations.push({
+              type: ptn.id,
+              file: rel(file),
+              line: i + 1,
+              excerpt: lines[i].trim().slice(0, 180),
+            });
+          }
+          ptn.re.lastIndex = 0;
+        }
+      }
+    }
+  }
+
+  return {
+    name: 'token-safety-batch-linter',
+    passed: violations.length === 0,
+    details: { violationsCount: violations.length },
+    violations,
+  };
+}
+
+function wireframeContractCheck() {
+  const required = ['layout', 'tokens', 'accessibility', 'states', 'assets'];
+  const files = walk(path.join(ROOT, 'docs/design/generated/wireframes'), ['.md']);
+  const violations = [];
+
+  for (const file of files) {
+    const txt = fs.readFileSync(file, 'utf8');
+    const missing = required.filter((tag) => !txt.includes(`<${tag}>`));
+    if (missing.length > 0) {
+      violations.push({
+        type: 'missing_wireframe_sections',
+        file: rel(file),
+        missing,
+      });
+    }
+  }
+
+  return {
+    name: 'wireframe-contract-validator',
+    passed: violations.length === 0,
+    details: { checkedFiles: files.length, violationsCount: violations.length },
+    violations,
+  };
+}
+
+async function visualAuditCheck() {
+  const targets = readJson(paths.visualTargets);
+  const probes = readJson(paths.runtimeProbes);
+  ensureDir(paths.previewsDir);
+
+  const results = [];
+  const server = await maybeStartFrontendServer(targets.baseUrl);
+  let browser;
+  let page;
+
+  try {
+    if (server.error) {
+      results.push({ targetId: 'frontend-server', passed: false, errors: [server.error] });
+    }
+    const playwright = await import('playwright');
+    browser = await playwright.chromium.launch({ headless: true });
+    page = await browser.newPage({ viewport: { width: 1440, height: 960 } });
+
+    for (const t of targets.targets) {
+      const probe = probes.targets.find((p) => p.targetId === t.id);
+      const record = {
+        targetId: t.id,
+        route: t.route,
+        url: probe?.url ?? targets.baseUrl + t.route,
+        screenshot: `docs/design/generated/previews/${t.id}.png`,
+        passed: true,
+        probeResults: [],
+        errors: [],
+      };
+
+      try {
+        await page.goto(record.url, { waitUntil: 'networkidle', timeout: 30000 });
+        await page.screenshot({ path: path.join(ROOT, record.screenshot), fullPage: true });
+
+        for (const check of probe?.checks ?? []) {
+          if (check.type === 'selectorExists') {
+            const exists = (await page.$(check.selector)) !== null;
+            record.probeResults.push({ ...check, pass: exists });
+            if (!exists) record.passed = false;
+          }
+          if (check.type === 'cssVarPresent') {
+            const found = await page.evaluate((sel, prop, valContains) => {
+              const el = document.querySelector(sel);
+              if (!el) return false;
+              const v = window.getComputedStyle(el).getPropertyValue(prop);
+              return v.includes(valContains);
+            }, check.selector, check.property, check.valueContains);
+            record.probeResults.push({ ...check, pass: found });
+            if (!found) record.passed = false;
+          }
+        }
+      } catch (error) {
+        record.passed = false;
+        record.errors.push(String(error));
+      }
+
+      results.push(record);
+    }
+  } catch (error) {
+    results.push({
+      targetId: 'visual-audit-engine',
+      passed: false,
+      errors: [`Playwright unavailable or failed: ${String(error)}`],
+    });
+  } finally {
+    if (page) await page.close();
+    if (browser) await browser.close();
+    if (server.started && server.child) server.child.kill('SIGTERM');
+  }
+
+  const failed = results.filter((r) => !r.passed);
+
+  return {
+    name: 'visual-audit',
+    passed: failed.length === 0,
+    details: {
+      checkedTargets: results.length,
+      failedTargets: failed.length,
+    },
+    results,
+  };
+}
+
+
+async function waitForPort(port, host = '127.0.0.1', timeoutMs = 45000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const ok = await new Promise((resolve) => {
+      const socket = new net.Socket();
+      socket.setTimeout(1000);
+      socket.once('connect', () => { socket.destroy(); resolve(true); });
+      socket.once('error', () => { socket.destroy(); resolve(false); });
+      socket.once('timeout', () => { socket.destroy(); resolve(false); });
+      socket.connect(port, host);
+    });
+    if (ok) return true;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+}
+
+async function maybeStartFrontendServer(baseUrl) {
+  let url;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    return { started: false };
+  }
+  const host = url.hostname || '127.0.0.1';
+  const port = Number(url.port || (url.protocol === 'https:' ? 443 : 80));
+
+  const alreadyUp = await waitForPort(port, host, 1500);
+  if (alreadyUp) return { started: false };
+
+  const child = spawn('yarn', ['workspace', 'careercopilot-frontend', 'dev', '--host', host, '--port', String(port)], {
+    stdio: 'ignore',
+    detached: false,
+  });
+
+  const up = await waitForPort(port, host, 60000);
+  if (!up) {
+    child.kill('SIGTERM');
+    return { started: false, error: `Unable to start frontend dev server on ${host}:${port}` };
+  }
+
+  return { started: true, child };
+}
+
+function writeGallery(results) {
+  const lines = ['# Visual Audit Gallery', '', `Generated: ${new Date().toISOString()}`, ''];
+  for (const r of results) {
+    lines.push(`## ${r.targetId}`);
+    lines.push(`- Route: ${r.route ?? 'n/a'}`);
+    lines.push(`- URL: ${r.url ?? 'n/a'}`);
+    lines.push(`- Status: ${r.passed ? 'PASS' : 'FAIL'}`);
+    if (r.screenshot && fs.existsSync(path.join(ROOT, r.screenshot))) {
+      lines.push(`![${r.targetId}](${path.relative(path.dirname(paths.galleryMd), path.join(ROOT, r.screenshot)).replaceAll('\\', '/')})`);
+    }
+    if (r.errors?.length) {
+      lines.push('- Errors:');
+      for (const e of r.errors) lines.push(`  - ${e}`);
+    }
+    lines.push('');
+  }
+  fs.writeFileSync(paths.galleryMd, lines.join('\n'));
+}
+
+function writeReadiness(manifest) {
+  const ci = {
+    runId: manifest.runId,
+    overallStatus: manifest.overallStatus,
+    stages: manifest.stages.map((s) => ({ name: s.name, passed: s.passed })),
+    visualAuditFailures: manifest.visualAuditFailures,
+    generatedAt: manifest.generatedAt,
+  };
+
+  ensureDir(path.dirname(paths.readinessJson));
+  fs.writeFileSync(paths.readinessJson, JSON.stringify(ci, null, 2));
+
+  const lines = [
+    '# Design Readiness',
+    '',
+    `- Run ID: ${manifest.runId}`,
+    `- Generated: ${manifest.generatedAt}`,
+    `- Overall Status: **${manifest.overallStatus.toUpperCase()}**`,
+    '',
+    '## Stage Results',
+  ];
+  for (const s of manifest.stages) {
+    lines.push(`- ${s.passed ? '✅' : '❌'} ${s.name}`);
+  }
+  lines.push('', `- Visual audit failures: ${manifest.visualAuditFailures}`);
+  lines.push(`- Run manifest: docs/design/runs/${manifest.runId}.json`);
+  fs.writeFileSync(paths.readinessMd, lines.join('\n'));
+}
+
+async function main() {
+  ensureDir(paths.runsDir);
+  ensureDir(path.dirname(paths.galleryMd));
+
+  const stages = [];
+  if (mode === 'all') {
+    stages.push(pathNormalizerCheck());
+    stages.push(tokenSafetyCheck());
+    stages.push(wireframeContractCheck());
+    const visual = await visualAuditCheck();
+    stages.push(visual);
+    writeGallery(visual.results ?? []);
+  } else if (mode === 'visual-audit') {
+    const visual = await visualAuditCheck();
+    stages.push(visual);
+    writeGallery(visual.results ?? []);
+  } else {
+    throw new Error(`Unsupported mode: ${mode}`);
+  }
+
+  const failures = stages.filter((s) => !s.passed).length;
+  const visualStage = stages.find((s) => s.name === 'visual-audit');
+  const manifest = {
+    runId,
+    generatedAt: new Date().toISOString(),
+    mode,
+    overallStatus: failures === 0 ? 'pass' : 'fail',
+    visualAuditFailures: visualStage?.details?.failedTargets ?? 0,
+    stages,
+  };
+
+  const runFile = path.join(paths.runsDir, `${runId}.json`);
+  fs.writeFileSync(runFile, JSON.stringify(manifest, null, 2));
+  writeReadiness(manifest);
+
+  console.log(`Design orchestrator completed: ${manifest.overallStatus}`);
+  console.log(`Run manifest: ${rel(runFile)}`);
+  console.log(`CI status: ${rel(paths.readinessJson)}`);
+
+  if (manifest.overallStatus === 'fail') {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/design/registry-hygiene.mjs
+++ b/scripts/design/registry-hygiene.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const skillsDir = path.join(ROOT, '.claude/skills');
+const registryPath = path.join(skillsDir, 'SKILL_REGISTRY.md');
+const outputPath = path.join(ROOT, 'docs/design/generated/skill-registry-hygiene.json');
+
+function walk(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+function rel(p) {
+  return path.relative(ROOT, p).replaceAll('\\', '/');
+}
+
+function parseDeclaredCount(md) {
+  const m = md.match(/Active skills:\s*\*\*(\d+)\*\*/);
+  return m ? Number(m[1]) : null;
+}
+
+function parseActiveRows(md) {
+  const rows = [];
+  const lines = md.split(/\r?\n/);
+  let inTable = false;
+  for (const line of lines) {
+    if (line.includes('| Skill | Directory | Description |')) {
+      inTable = true;
+      continue;
+    }
+    if (!inTable) continue;
+    if (!line.startsWith('|')) {
+      if (rows.length > 0) break;
+      continue;
+    }
+    if (line.startsWith('|---')) continue;
+    const parts = line.split('|').map((s) => s.trim()).filter(Boolean);
+    if (parts.length >= 3) rows.push({ skill: parts[0], directory: parts[1], description: parts[2] });
+  }
+  return rows;
+}
+
+function main() {
+  const registry = fs.readFileSync(registryPath, 'utf8');
+  const declaredCount = parseDeclaredCount(registry);
+  const tableRows = parseActiveRows(registry);
+
+  const directEntries = fs.readdirSync(skillsDir, { withFileTypes: true });
+  const activeSkillDirs = directEntries
+    .filter((e) => e.isDirectory() && !e.name.startsWith('_legacy_archive'))
+    .map((e) => path.join(skillsDir, e.name))
+    .filter((d) => fs.existsSync(path.join(d, 'SKILL.md')));
+
+  const normalize = (v) => v.replaceAll('\\', '/').replace(/^\.\//, '').replace(/^\//, '');
+  const tableDirs = new Set(tableRows.map((r) => normalize(r.directory)));
+  const discoveredDirs = new Set(activeSkillDirs.map((d) => normalize(rel(d))));
+
+  const orphanedSkillDirs = [...discoveredDirs].filter((d) => !tableDirs.has(d));
+  const staleTableDirs = [...tableDirs].filter((d) => !discoveredDirs.has(d));
+
+  const result = {
+    generatedAt: new Date().toISOString(),
+    declaredCount,
+    activeTableCount: tableRows.length,
+    discoveredActiveSkillCount: activeSkillDirs.length,
+    summaryCountMatchesTable: declaredCount === tableRows.length,
+    tableMatchesFilesystem: tableRows.length === activeSkillDirs.length && orphanedSkillDirs.length === 0 && staleTableDirs.length === 0,
+    orphanedSkillDirs,
+    staleTableDirs,
+  };
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
+
+  console.log(`Registry hygiene report: ${rel(outputPath)}`);
+  console.log(`Declared: ${declaredCount}, Table: ${tableRows.length}, Filesystem active: ${activeSkillDirs.length}`);
+
+  if (!result.summaryCountMatchesTable || !result.tableMatchesFilesystem) {
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
Addresses review comments on the orchestrator scaffold PR without changing yarn-based execution.

### Changes made
1. **CI trigger logic updated** (`.github/workflows/ci.yml`)
   - `design-orchestrator` now runs for `pull_request`, `push`, and `workflow_dispatch`.
   - It is gated on `needs.changes.outputs.design == 'true'` for PR/push events.
   - For `workflow_dispatch`, it can run without path-filter output.

2. **Scaffold clarification comment added** (`scripts/design/orchestrate.mjs`)
   - Added top-of-file header noting this is an integrated scaffold for `frontend-design-orchestrator`.
   - Clarifies future extraction of `path-normalizer`, `token-safety-batch-linter`, and `wireframe-contract-validator` into separate modules while preserving CLI contract.

3. **Explicit yarn run instructions + outputs reinforced** (`docs/design/design-orchestrator-plan.md`)
   - Kept and emphasized:
     - `yarn design:orchestrate:all`
     - `yarn design:orchestrate:visual-audit`
   - Added explicit output locations to verify after each run.

4. **Visual-audit/probe TODO status added**
   - `design/contracts/visual-audit-targets.json`: added `INITIAL_SCAFFOLD_TODO` note.
   - `design/contracts/runtime-probes.json`: added `INITIAL_SCAFFOLD_TODO` note.
   - `docs/design/design-orchestrator-plan.md`: added scaffold status section noting Lens/Jar coverage is not complete yet.

## Validation
- `node --check scripts/design/orchestrate.mjs`
- `python -m json.tool design/contracts/visual-audit-targets.json`
- `python -m json.tool design/contracts/runtime-probes.json`
- `rg -n "design-orchestrator|INITIAL_SCAFFOLD_TODO|Scaffold status|design:orchestrate" ...` to confirm trigger/docs/notes are present.

## Local commands to run
- `yarn design:orchestrate:all`
- `yarn design:orchestrate:visual-audit`

Expected artifacts:
- `docs/design/generated/design-readiness.json`
- `docs/design/design-readiness.md`
- `docs/design/runs/<timestamp>.json`
- `docs/design/generated/visual-audit-gallery.md`
- `docs/design/generated/previews/<targetId>.png`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e457257883259954bba14c8d933b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI gate to run a Design Orchestrator that performs automated design verification, visual audits, and uploads readiness artifacts
  * New scripts to run end-to-end design orchestration and registry hygiene locally or in CI

* **Documentation**
  * Added detailed design automation guides, skill lifecycle, contracts, visual-audit targets, and legacy-workflow notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->